### PR TITLE
10 orden de renderizado

### DIFF
--- a/MatrixWorld/Assets/Prefab/Player.prefab
+++ b/MatrixWorld/Assets/Prefab/Player.prefab
@@ -73,8 +73,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 433258337
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 7482667652216324306, guid: 5a06d04373856694fb871e81bcbc69d2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/MatrixWorld/Assets/Prefab/Void.prefab
+++ b/MatrixWorld/Assets/Prefab/Void.prefab
@@ -73,8 +73,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -236828907
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: 7482667652216324306, guid: 5a06d04373856694fb871e81bcbc69d2, type: 3}
   m_Color: {r: 0.6192043, g: 0.42241198, b: 0.74213827, a: 1}

--- a/MatrixWorld/Assets/Scenes/SampleScene.unity
+++ b/MatrixWorld/Assets/Scenes/SampleScene.unity
@@ -180,7 +180,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 5
+  orthographic size: 8
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2

--- a/MatrixWorld/ProjectSettings/TagManager.asset
+++ b/MatrixWorld/ProjectSettings/TagManager.asset
@@ -2,7 +2,7 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!78 &1
 TagManager:
-  serializedVersion: 2
+  serializedVersion: 3
   tags: []
   layers:
   - Default
@@ -41,3 +41,11 @@ TagManager:
   - name: Default
     uniqueID: 0
     locked: 0
+  - name: World
+    uniqueID: 4058138389
+    locked: 0
+  - name: Entity
+    uniqueID: 433258337
+    locked: 0
+  m_RenderingLayers:
+  - Default


### PR DESCRIPTION
Complete #10. Se establecieron 2 capas de renderizado ordenadas por profundidad:
1. World: para elementos del mundo estáticos.
2. Entity: para entidades con movimiento.